### PR TITLE
'root' is a link to the input file, not the cache file name

### DIFF
--- a/less.php
+++ b/less.php
@@ -109,7 +109,7 @@ class plgSystemLess extends JPlugin
 		if (file_exists($cacheFile))
 		{
 			$tmpCache = unserialize(file_get_contents($cacheFile));
-			if ($tmpCache['root'] === $cacheFile)
+			if ($tmpCache['root'] === $inputFile)
 			{
 				$cache = $tmpCache;
 			}


### PR DESCRIPTION
The `'root'` element of the cached object is the filename of the input file not the filename of the cache.

https://github.com/leafo/lessphp/blob/master/lessc.inc.php#L1939

Using the comparison `=== $cacheFile` causes the less to be re-compiled on every page load because it will never match.
